### PR TITLE
Add local error class.

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -127,7 +127,7 @@ def init(cfg_file = None):
     
     result = _hdl.sensors_init(file)
     if result != 0:
-        raise_sensor_error(reslt, "sensors_init failed")
+        raise_sensor_error(result, "sensors_init failed")
     
     if file is not None:
         _libc.fclose(file)

--- a/sensors.py
+++ b/sensors.py
@@ -21,6 +21,9 @@ _hdl = cdll.LoadLibrary(ctypes.util.find_library("sensors"))
 
 version = c_char_p.in_dll(_hdl, "libsensors_version").value.decode("ascii")
 
+class error(Exception):
+    pass
+
 class bus_id(Structure):
     _fields_ = [("type", c_short),
                 ("nr", c_short)]
@@ -73,7 +76,7 @@ def init(cfg_file = None):
     file = _libc.fopen(cfg_file.encode("utf-8"), "r") if cfg_file is not None else None 
     
     if _hdl.sensors_init(file) != 0:
-        raise Exception("sensors_init failed")
+        raise error("sensors_init failed")
     
     if file is not None:
         _libc.fclose(file)
@@ -86,7 +89,7 @@ def parse_chip_name(orig_name):
     err= _hdl.sensors_parse_chip_name(orig_name.encode("utf-8"), byref(ret))
     
     if err < 0:
-        raise Exception(strerror(err))
+        raise error(strerror(err))
     
     return ret
 
@@ -117,7 +120,7 @@ def chip_snprintf_name(chip, buffer_size=200):
     err = _hdl.sensors_snprintf_chip_name(ret, buffer_size, byref(chip))
     
     if err < 0:
-        raise Exception(strerror(err))
+        raise error(strerror(err))
         
     return ret.value.decode("utf-8")
 
@@ -127,7 +130,7 @@ def do_chip_sets(chip):
     """
     err = _hdl.sensors_do_chip_sets(byref(chip))
     if err < 0:
-        raise Exception(strerror(err))
+        raise error(strerror(err))
     
 def get_adapter_name(bus):
     return _hdl.sensors_get_adapter_name(byref(bus)).decode("utf-8")
@@ -160,7 +163,7 @@ def get_value(chip, subfeature_nr):
     val = c_double()
     err = _hdl.sensors_get_value(byref(chip), subfeature_nr, byref(val))
     if err < 0:
-        raise Exception(strerror(err))
+        raise error(strerror(err))
     return val.value
 
 def set_value(chip, subfeature_nr, value):
@@ -170,7 +173,7 @@ def set_value(chip, subfeature_nr, value):
     val = c_double(value)
     err = _hdl.sensors_set_value(byref(chip), subfeature_nr, byref(val))
     if err < 0:
-        raise Exception(strerror(err))
+        raise error(strerror(err))
 
 ### Convenience API ###
 class ChipIterator:

--- a/sensors.py
+++ b/sensors.py
@@ -21,8 +21,58 @@ _hdl = cdll.LoadLibrary(ctypes.util.find_library("sensors"))
 
 version = c_char_p.in_dll(_hdl, "libsensors_version").value.decode("ascii")
 
-class error(Exception):
+class SensorsError(Exception):
     pass
+
+class ErrorWildcards(SensorsError):
+    pass
+
+class ErrorNoEntry(SensorsError):
+    pass
+
+class ErrorAccessRead(SensorsError, PermissionError):
+    pass
+
+class ErrorKernel(SensorError, OSError):
+    pass
+
+class ErrorDivZero(SensorError, ZeroDivisionError):
+    pass
+
+class ErrorChipName(SensorError):
+    pass
+
+class ErrorBusName(SensorError):
+    pass
+
+class ErrorParse(SensorError):
+    pass
+
+class ErrorAccessWrite(SensorError, PermissionError):
+    pass
+
+class ErrorIO(SensorError, IOError):
+    pass
+
+class ErrorRecursion(SensorError):
+    pass
+
+_ERR_MAP = {
+    1: ErrorWildcards,
+    2: ErrorNoEntry,
+    3: ErrorAccessRead,
+    4: ErrorKernel,
+    5: ErrorDivZero,
+    6: ErrorChipName,
+    7: ErrorBusName,
+    8: ErrorParse,
+    9: ErrorAccessWrite,
+    10: ErrorIO,
+    11: ErrorRecursion
+}
+
+def raise_sensor_error(errno, message=''):
+    raise _ERR_MAP[abs(errno)](message)
 
 class bus_id(Structure):
     _fields_ = [("type", c_short),
@@ -75,8 +125,9 @@ COMPUTE_MAPPING = 4
 def init(cfg_file = None):
     file = _libc.fopen(cfg_file.encode("utf-8"), "r") if cfg_file is not None else None 
     
-    if _hdl.sensors_init(file) != 0:
-        raise error("sensors_init failed")
+    result = _hdl.sensors_init(file)
+    if result != 0:
+        raise_sensor_error(reslt, "sensors_init failed")
     
     if file is not None:
         _libc.fclose(file)
@@ -89,7 +140,7 @@ def parse_chip_name(orig_name):
     err= _hdl.sensors_parse_chip_name(orig_name.encode("utf-8"), byref(ret))
     
     if err < 0:
-        raise error(strerror(err))
+        raise_sensor_error(err, strerror(err))
     
     return ret
 
@@ -120,7 +171,7 @@ def chip_snprintf_name(chip, buffer_size=200):
     err = _hdl.sensors_snprintf_chip_name(ret, buffer_size, byref(chip))
     
     if err < 0:
-        raise error(strerror(err))
+        raise_sensor_error(err, strerror(err))
         
     return ret.value.decode("utf-8")
 
@@ -130,7 +181,7 @@ def do_chip_sets(chip):
     """
     err = _hdl.sensors_do_chip_sets(byref(chip))
     if err < 0:
-        raise error(strerror(err))
+        raise_sensor_error(err, strerror(err))
     
 def get_adapter_name(bus):
     return _hdl.sensors_get_adapter_name(byref(bus)).decode("utf-8")
@@ -163,7 +214,7 @@ def get_value(chip, subfeature_nr):
     val = c_double()
     err = _hdl.sensors_get_value(byref(chip), subfeature_nr, byref(val))
     if err < 0:
-        raise error(strerror(err))
+        raise_sensor_error(err, strerror(err))
     return val.value
 
 def set_value(chip, subfeature_nr, value):
@@ -173,7 +224,7 @@ def set_value(chip, subfeature_nr, value):
     val = c_double(value)
     err = _hdl.sensors_set_value(byref(chip), subfeature_nr, byref(val))
     if err < 0:
-        raise error(strerror(err))
+        raise_sensor_error(err, strerror(err))
 
 ### Convenience API ###
 class ChipIterator:


### PR DESCRIPTION
Requiring users to catch a raw Exception instead of providing our own error class is bad, it encourages bad coding habits and forces users to write code that can hide real bugs.

Instead, define a local subclass of Exception, and throw that instead.